### PR TITLE
customize-for-crm2016

### DIFF
--- a/fetchxml-web/Properties/launchSettings.json
+++ b/fetchxml-web/Properties/launchSettings.json
@@ -1,18 +1,8 @@
-﻿{
-  "$schema": "http://json.schemastore.org/launchsettings.json",
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:1971",
-      "sslPort": 44376
-    }
-  },
+{
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "weatherforecast",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -21,10 +11,19 @@
       "commandName": "Project",
       "launchBrowser": true,
       "launchUrl": "weatherforecast",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  },
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:1971",
+      "sslPort": 44376
     }
   }
 }

--- a/fetchxml/FetchXml/FetchXml.cs
+++ b/fetchxml/FetchXml/FetchXml.cs
@@ -365,8 +365,22 @@ namespace FetchXml.Model
         [XmlAttributeAttribute("alias")]
         public string Alias { get; set; }
 
+        [XmlIgnoreAttribute()]
+        private string _link_Type = "inner";
+
+        [DefaultValueAttribute("inner")]
         [XmlAttributeAttribute("link-type")]
-        public string Link_Type { get; set; }
+        public string Link_Type
+        {
+            get
+            {
+                return _link_Type;
+            }
+            set
+            {
+                _link_Type = value;
+            }
+        }
 
         [XmlAttributeAttribute("visible")]
         public bool Visible { get; set; }

--- a/fetchxml/FetchXml/FetchXml.xsd
+++ b/fetchxml/FetchXml/FetchXml.xsd
@@ -192,7 +192,8 @@
     <xs:attribute name="alias"
                   type="xs:string"></xs:attribute>
     <xs:attribute name="link-type"
-                  type="xs:string"></xs:attribute>
+                  type="xs:string"									
+									default="inner"></xs:attribute>
     <xs:attribute name="visible"
                   type="xs:boolean"></xs:attribute>
     <xs:attribute name="intersect"


### PR DESCRIPTION
1. Modify FetchXML.xsd: set link-type default to "inner"
2. Take care of some special cases when generating filter conditions: a. number or boolean value in "ne" or "neq": append a nullable check, because most entity columns are nullable, and when you use "not-equal" operator, null values will not be selected. b. Guid: FecthXML's Guid are wrapped in curly braces, while in Sql server it's not.
3. Adjust launchSettings.json.